### PR TITLE
Reduce Maybes

### DIFF
--- a/src/Remote/Data.elm
+++ b/src/Remote/Data.elm
@@ -2,9 +2,9 @@ module Remote.Data exposing
     ( RemoteData(..), GraphqlHttpData
     , fromResponse
     , isSuccess, isError, isCustomError, isTransportError, isLoading, isNotAsked
-    , toError
     , map, mapCustomError, mapTransportError, mapErrors
-    , withDefault, merge
+    , toError, withDefault, merge
+    , reduceMaybe
     )
 
 {-| A datatype representing fetched data in five different states.
@@ -34,9 +34,9 @@ and aliasing `GraphqlError` instead of `Http.Error`.
 
 # Common transformations
 
-@docs toError
 @docs map, mapCustomError, mapTransportError, mapErrors
-@docs withDefault, merge
+@docs toError, withDefault, merge
+@docs reduceMaybe
 
 -}
 
@@ -337,3 +337,24 @@ isNotAsked data =
 
         _ ->
             False
+
+
+{-| This helper was projected for reducing switch-case entries when working with collections.
+
+    case
+        entries
+            |> Dict.get id
+            |> RemoteData.reduceMaybe
+    of
+        RemoteData.NotAsked ->
+            Element.text "Request was never prompted"
+
+        _ ->
+            Element.text "Request was once prompted"
+
+-}
+reduceMaybe :
+    Maybe (RemoteData transportError customError object)
+    -> RemoteData transportError customError object
+reduceMaybe maybe =
+    Maybe.withDefault NotAsked maybe

--- a/src/Remote/Recyclable.elm
+++ b/src/Remote/Recyclable.elm
@@ -566,7 +566,7 @@ isNeverAsked data =
     case
         entries
             |> Dict.get id
-            |> RemoteData.reduceMaybe
+            |> Recyclable.reduceMaybe
     of
         Recyclable.NeverAsked ->
             Element.text "Request was never prompted"
@@ -576,7 +576,7 @@ isNeverAsked data =
 
 -}
 reduceMaybe :
-    Maybe (RemoteData transportError customError object)
-    -> RemoteData transportError customError object
+    Maybe (Recyclable transportError customError object)
+    -> Recyclable transportError customError object
 reduceMaybe maybe =
-    Maybe.withDefault NotAsked maybe
+    Maybe.withDefault NeverAsked maybe

--- a/src/Remote/Recyclable.elm
+++ b/src/Remote/Recyclable.elm
@@ -3,9 +3,9 @@ module Remote.Recyclable exposing
     , firstLoading
     , mergeResponse, toLoading, fromResponse
     , isReady, isError, isCustomError, isTransportError, isLoading, isNeverAsked
-    , toError
     , map, mapCustomError, mapTransportError, mapErrors
-    , withDefault, merge
+    , toError, withDefault, merge
+    , reduceMaybe
     )
 
 {-| This module extends [`Data`](Remote-Data) preserving the information when reloading the same source.
@@ -118,9 +118,9 @@ Then, on "update" you're gonna be using either:
 
 # Common transformations
 
-@docs toError
 @docs map, mapCustomError, mapTransportError, mapErrors
-@docs withDefault, merge
+@docs toError, withDefault, merge
+@docs reduceMaybe
 
 -}
 
@@ -559,3 +559,24 @@ isNeverAsked data =
 
         _ ->
             False
+
+
+{-| This helper was projected for reducing switch-case entries when working with collections.
+
+    case
+        entries
+            |> Dict.get id
+            |> RemoteData.reduceMaybe
+    of
+        Recyclable.NeverAsked ->
+            Element.text "Request was never prompted"
+
+        _ ->
+            Element.text "Request was once prompted"
+
+-}
+reduceMaybe :
+    Maybe (RemoteData transportError customError object)
+    -> RemoteData transportError customError object
+reduceMaybe maybe =
+    Maybe.withDefault NotAsked maybe


### PR DESCRIPTION
#### :thinking: What?
Add function `reduceMaybe` to `RemoteData` and `Recyclable`


#### :man_shrugging: Why?
When switch-casing through `Dict.get` and `List.head` results, we usually end up with two branches (`Just NotAsked` and `Nothing`) having the same meaning (the request wasn't realized).
Using this helper we can avoid repeating code or creating a more specialized data structure.


#### :pushpin: Jira Issue
None, this repo is not tracked.


#### :no_good: Blocked by
Not blocked and based on master.


#### :clipboard: Pending
Nothing.


### :fire: Extra
This PR is a proposal and it's open to counter-arguments.