### PR TITLE
Fix broken elm-graphql package link

### DIFF
--- a/src/Remote/Errors.elm
+++ b/src/Remote/Errors.elm
@@ -18,7 +18,7 @@ type RemoteError transportError customError
 
 {-| Implementation of [`RemoteError`](#RemoteError) for failures containing [`Graphql.Http.GraphqlError`][GraphqlError]
 
-[GraphqlError]: /dillonkearns/elm-graphql/latest/Graphql-Http-GraphqlError
+[GraphqlError]: /packages/dillonkearns/elm-graphql/latest/Graphql-Http-GraphqlError
 
 -}
 type alias GraphqlHttpError customError =


### PR DESCRIPTION
Correctly link to `/packages/dillonkearns/elm-graphql/latest/Graphql-Http-GraphqlError` for GraphqlError link.